### PR TITLE
Update timings and init for v1 & v2 panels @ 60hz

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-353m.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-353m.dts
@@ -613,42 +613,42 @@
 			15 00 02 FF 30
 			15 00 02 FF 52
 			15 00 02 FF 02
-			15 00 02 B1 0E
-			15 00 02 D1 0E
-			15 00 02 B4 29
-			15 00 02 D4 2B
-			15 00 02 B2 0C
-			15 00 02 D2 0A
-			15 00 02 B3 28
-			15 00 02 D3 28
-			15 00 02 B6 11
-			15 00 02 D6 0D
-			15 00 02 B7 32
-			15 00 02 D7 30
-			15 00 02 C1 04
-			15 00 02 E1 06
-			15 00 02 B8 0A
-			15 00 02 D8 0A
-			15 00 02 B9 01
-			15 00 02 D9 01
-			15 00 02 BD 13
-			15 00 02 DD 13
-			15 00 02 BC 11
-			15 00 02 DC 11
-			15 00 02 BB 0F
-			15 00 02 DB 0F
-			15 00 02 BA 0F
-			15 00 02 DA 0F
-			15 00 02 BE 18
-			15 00 02 DE 18
-			15 00 02 BF 0F
-			15 00 02 DF 0F
-			15 00 02 C0 17
-			15 00 02 E0 17
-			15 00 02 B5 3B
-			15 00 02 D5 3C
 			15 00 02 B0 0B
+			15 00 02 B1 16
+			15 00 02 B2 17
+			15 00 02 B3 2C
+			15 00 02 B4 32
+			15 00 02 B5 3B
+			15 00 02 B6 29
+			15 00 02 B7 40
+			15 00 02 B8 0D
+			15 00 02 B9 05
+			15 00 02 BA 12
+			15 00 02 BB 10
+			15 00 02 BC 12
+			15 00 02 BD 15
+			15 00 02 BE 19
+			15 00 02 BF 0E
+			15 00 02 C0 16
+			15 00 02 C1 0A
 			15 00 02 D0 0C
+			15 00 02 D1 17
+			15 00 02 D2 14
+			15 00 02 D3 2E
+			15 00 02 D4 32
+			15 00 02 D5 3C
+			15 00 02 D6 22
+			15 00 02 D7 3D
+			15 00 02 D8 0D
+			15 00 02 D9 07
+			15 00 02 DA 13
+			15 00 02 DB 13
+			15 00 02 DC 11
+			15 00 02 DD 15
+			15 00 02 DE 19
+			15 00 02 DF 10
+			15 00 02 E0 17
+			15 00 02 E1 0A
 			15 00 02 FF 30
 			15 00 02 FF 52
 			15 00 02 FF 03
@@ -765,15 +765,15 @@
 		disp_timings0: display-timings {
 			native-mode = <&dsi0_timing0>;
 			dsi0_timing0: timing0 {
-				clock-frequency = <26400000>;
+				clock-frequency = <49996200>;
 				hactive = <640>;
 				vactive = <480>;
-				hfront-porch = <119>;
-				hsync-len = <2>;
-				hback-porch = <119>;
-				vfront-porch = <13>;
-				vsync-len = <2>;
-				vback-porch = <5>;			
+				hfront-porch = <458>;
+				hsync-len = <70>;
+				hback-porch = <450>;
+				vfront-porch = <17>;
+				vsync-len = <5>;
+				vback-porch = <13>;			
 				hsync-active = <0>;
 				vsync-active = <0>;
 				de-active = <0>;
@@ -834,12 +834,12 @@
 		disp_timings1: display-timings {
 			native-mode = <&dsi0_timing1>;
 			dsi0_timing1: timing1 {
-				clock-frequency = <50000000>;
+				clock-frequency = <49996200>;
 				hactive = <640>;
 				vactive = <480>;
-				hfront-porch = <450>;
-				hback-porch = <450>;
+				hfront-porch = <458>;
 				hsync-len = <70>;
+				hback-porch = <450>;
 				vfront-porch = <17>;
 				vsync-len = <5>;
 				vback-porch = <13>;			

--- a/arch/arm64/boot/dts/rockchip/rk3566-353v.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-353v.dts
@@ -613,42 +613,42 @@
 			15 00 02 FF 30
 			15 00 02 FF 52
 			15 00 02 FF 02
-			15 00 02 B1 0E
-			15 00 02 D1 0E
-			15 00 02 B4 29
-			15 00 02 D4 2B
-			15 00 02 B2 0C
-			15 00 02 D2 0A
-			15 00 02 B3 28
-			15 00 02 D3 28
-			15 00 02 B6 11
-			15 00 02 D6 0D
-			15 00 02 B7 32
-			15 00 02 D7 30
-			15 00 02 C1 04
-			15 00 02 E1 06
-			15 00 02 B8 0A
-			15 00 02 D8 0A
-			15 00 02 B9 01
-			15 00 02 D9 01
-			15 00 02 BD 13
-			15 00 02 DD 13
-			15 00 02 BC 11
-			15 00 02 DC 11
-			15 00 02 BB 0F
-			15 00 02 DB 0F
-			15 00 02 BA 0F
-			15 00 02 DA 0F
-			15 00 02 BE 18
-			15 00 02 DE 18
-			15 00 02 BF 0F
-			15 00 02 DF 0F
-			15 00 02 C0 17
-			15 00 02 E0 17
-			15 00 02 B5 3B
-			15 00 02 D5 3C
 			15 00 02 B0 0B
+			15 00 02 B1 16
+			15 00 02 B2 17
+			15 00 02 B3 2C
+			15 00 02 B4 32
+			15 00 02 B5 3B
+			15 00 02 B6 29
+			15 00 02 B7 40
+			15 00 02 B8 0D
+			15 00 02 B9 05
+			15 00 02 BA 12
+			15 00 02 BB 10
+			15 00 02 BC 12
+			15 00 02 BD 15
+			15 00 02 BE 19
+			15 00 02 BF 0E
+			15 00 02 C0 16
+			15 00 02 C1 0A
 			15 00 02 D0 0C
+			15 00 02 D1 17
+			15 00 02 D2 14
+			15 00 02 D3 2E
+			15 00 02 D4 32
+			15 00 02 D5 3C
+			15 00 02 D6 22
+			15 00 02 D7 3D
+			15 00 02 D8 0D
+			15 00 02 D9 07
+			15 00 02 DA 13
+			15 00 02 DB 13
+			15 00 02 DC 11
+			15 00 02 DD 15
+			15 00 02 DE 19
+			15 00 02 DF 10
+			15 00 02 E0 17
+			15 00 02 E1 0A
 			15 00 02 FF 30
 			15 00 02 FF 52
 			15 00 02 FF 03
@@ -765,15 +765,15 @@
 		disp_timings0: display-timings {
 			native-mode = <&dsi0_timing0>;
 			dsi0_timing0: timing0 {
-				clock-frequency = <26400000>;
+				clock-frequency = <49996200>;
 				hactive = <640>;
 				vactive = <480>;
-				hfront-porch = <119>;
-				hsync-len = <2>;
-				hback-porch = <119>;
-				vfront-porch = <13>;
-				vsync-len = <2>;
-				vback-porch = <5>;			
+				hfront-porch = <458>;
+				hsync-len = <70>;
+				hback-porch = <450>;
+				vfront-porch = <17>;
+				vsync-len = <5>;
+				vback-porch = <13>;			
 				hsync-active = <0>;
 				vsync-active = <0>;
 				de-active = <0>;
@@ -834,12 +834,12 @@
 		disp_timings1: display-timings {
 			native-mode = <&dsi0_timing1>;
 			dsi0_timing1: timing1 {
-				clock-frequency = <50000000>;
+				clock-frequency = <49996200>;
 				hactive = <640>;
 				vactive = <480>;
-				hfront-porch = <450>;
-				hback-porch = <450>;
+				hfront-porch = <458>;
 				hsync-len = <70>;
+				hback-porch = <450>;
 				vfront-porch = <17>;
 				vsync-len = <5>;
 				vback-porch = <13>;			


### PR DESCRIPTION
Introduce a new init sequence for the Anbernic RG353x series v1 panel to restore color profile and saturation settings. Enables 60hz vertical refresh at higher clock frequencies without causing display artifacts.  

Reuse the same frequency on v2 panels, with stock panel init sequence.